### PR TITLE
Timing test fixes

### DIFF
--- a/CSharpRoboticsLibrary/Extras/Utility.cs
+++ b/CSharpRoboticsLibrary/Extras/Utility.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Threading;
 
 namespace CSharpRoboticsLib.Extras
 {
@@ -50,11 +51,21 @@ namespace CSharpRoboticsLib.Extras
         /// <param name="time">Time in seconds to wait</param>
         public static void AccurateWaitSeconds(double time)
         {
-            Stopwatch timer = new Stopwatch();
-            timer.Restart();
-            while (timer.Elapsed.TotalSeconds < time)
-                ;
+            Stopwatch sw = new Stopwatch();
+            sw.Start();
+            double ticks = (Stopwatch.Frequency * time);
+            
+            int milliSeconds = (int)(time * 1e3);
+
+            if (milliSeconds >= 20)
+            {
+                Thread.Sleep(milliSeconds - 12);
+            }
+            while (sw.ElapsedTicks < ticks) ;
+            sw.Stop();
         }
+
+        
 
         /// <summary>
         /// Waits for a specified time more accurately than Thread.Sleep()
@@ -62,10 +73,20 @@ namespace CSharpRoboticsLib.Extras
         /// <param name="time">Time in milliseconds to wait</param>
         public static void AccurateWaitMilliseconds(double time)
         {
-            Stopwatch timer = new Stopwatch();
-            timer.Restart();
-            while (timer.Elapsed.TotalMilliseconds < time)
-                ;
+            
+            Stopwatch sw = new Stopwatch();
+            sw.Start();
+            int milliSeconds = (int)time;
+            time = time / 1000;
+            double ticks = (Stopwatch.Frequency * time);
+
+            if (milliSeconds >= 20)
+            {
+                Thread.Sleep(milliSeconds - 12);
+            }
+            
+            while (sw.ElapsedTicks < ticks) ;
+            sw.Stop();
         }
     }
 }

--- a/CSharpRoboticsLibrary/NILabview/DeltaTime.cs
+++ b/CSharpRoboticsLibrary/NILabview/DeltaTime.cs
@@ -31,7 +31,7 @@ namespace CSharpRoboticsLib.NILabview
             {
                 if (!m_manualDt)
                 {
-                    m_Dt = m_timer.Elapsed.TotalSeconds;
+                    m_Dt = (double)m_timer.ElapsedTicks / Stopwatch.Frequency;
                     m_timer.Restart();
                 }
                 return m_Dt;

--- a/IndependentTests/ExtrasTests/UtilityTest.cs
+++ b/IndependentTests/ExtrasTests/UtilityTest.cs
@@ -80,7 +80,6 @@ namespace IndependentTests.ExtrasTests
                 Utility.AccurateWaitMilliseconds(100);
                 sw.Stop();
                 var seconds = (double)sw.ElapsedTicks / Stopwatch.Frequency;
-                Console.WriteLine(seconds);
                 Assert.That(seconds, Is.EqualTo(0.1).Within(Error));
             }
         }

--- a/IndependentTests/ExtrasTests/UtilityTest.cs
+++ b/IndependentTests/ExtrasTests/UtilityTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using NUnit.Framework;
 using CSharpRoboticsLib.Extras;
 
@@ -15,33 +16,86 @@ namespace IndependentTests.ExtrasTests
         [Test]
         public void AccurateWaitTest1hz()
         {
+            Stopwatch sw = new Stopwatch();
             for (int i = 0; i < TestRepeats / 10; i++) //Ain't nobody got time to wait 20 seconds for a test!
             {
-                DateTime dt = DateTime.Now;
-                Utility.AccurateWaitSeconds(1);
-                Assert.AreEqual(1, (DateTime.Now - dt).TotalSeconds, Error);
+                sw.Restart();
+                Utility.AccurateWaitSeconds(1.0);
+                sw.Stop();
+                var seconds = sw.Elapsed.TotalSeconds;
+                Assert.That(seconds, Is.EqualTo(1.0).Within(Error));
             }
         }
 
         [Test]
         public void AccurateWait10hz()
         {
+            Stopwatch sw = new Stopwatch();
             for (int i = 0; i < TestRepeats; i++)
             {
-                DateTime dt = DateTime.Now;
+                sw.Restart();
                 Utility.AccurateWaitSeconds(0.1);
-                Assert.AreEqual(0.1, (DateTime.Now - dt).TotalSeconds, Error);
+                sw.Stop();
+                var seconds = (double)sw.ElapsedTicks / Stopwatch.Frequency;
+                Assert.That(seconds, Is.EqualTo(0.1).Within(Error));
             }
         }
 
         [Test]
         public void AccurateWait100hz()
         {
-            for(int i = 0; i < TestRepeats; i++)
+            Stopwatch sw = new Stopwatch();
+            for (int i = 0; i < TestRepeats; i++)
             {
-                DateTime dt = DateTime.Now;
+                sw.Restart();
                 Utility.AccurateWaitSeconds(0.01);
-                Assert.AreEqual(0.01, (DateTime.Now - dt).TotalSeconds, Error);
+                sw.Stop();
+                var seconds = (double)sw.ElapsedTicks / Stopwatch.Frequency;
+                Assert.That(seconds, Is.EqualTo(0.01).Within(Error));
+            }
+        }
+
+
+        [Test]
+        public void AccurateWaitTest1hzMs()
+        {
+            Stopwatch sw = new Stopwatch();
+            for (int i = 0; i < TestRepeats / 10; i++) //Ain't nobody got time to wait 20 seconds for a test!
+            {
+                sw.Restart();
+                Utility.AccurateWaitMilliseconds(1000);
+                sw.Stop();
+                var seconds = sw.Elapsed.TotalSeconds;
+                Assert.That(seconds, Is.EqualTo(1.0).Within(Error));
+            }
+        }
+
+        [Test]
+        public void AccurateWait10hzMs()
+        {
+            Stopwatch sw = new Stopwatch();
+            for (int i = 0; i < TestRepeats; i++)
+            {
+                sw.Restart();
+                Utility.AccurateWaitMilliseconds(100);
+                sw.Stop();
+                var seconds = (double)sw.ElapsedTicks / Stopwatch.Frequency;
+                Console.WriteLine(seconds);
+                Assert.That(seconds, Is.EqualTo(0.1).Within(Error));
+            }
+        }
+
+        [Test]
+        public void AccurateWait100hzMs()
+        {
+            Stopwatch sw = new Stopwatch();
+            for (int i = 0; i < TestRepeats; i++)
+            {
+                sw.Restart();
+                Utility.AccurateWaitMilliseconds(10);
+                sw.Stop();
+                var seconds = (double)sw.ElapsedTicks / Stopwatch.Frequency;
+                Assert.That(seconds, Is.EqualTo(0.01).Within(Error));
             }
         }
     }

--- a/IndependentTests/NILabviewTests/DerivativeTest.cs
+++ b/IndependentTests/NILabviewTests/DerivativeTest.cs
@@ -17,10 +17,11 @@ namespace IndependentTests.NILabviewTests
         public void DerivativePositiveTest10hz()
         {
             Derivative d = new Derivative(0);
+            d.Dt = 0.1;
             Assert.AreEqual(0, d.Get(0), double.Epsilon);
             for (int i = 0; i < TestRepeats; i++)
             {
-                Utility.AccurateWaitSeconds(0.1);
+                //Utility.AccurateWaitSeconds(0.1);
                 Assert.AreEqual(1, d.Get(0.1 * (i + 1)), AcceptibleError);
             }
         }
@@ -29,10 +30,11 @@ namespace IndependentTests.NILabviewTests
         public void DerivativeNegativeTest10hz()
         {
             Derivative d = new Derivative(0);
+            d.Dt = 0.1;
             Assert.AreEqual(0, d.Get(0), double.Epsilon);
             for (int i = 0; i < TestRepeats; i++)
             {
-                Utility.AccurateWaitSeconds(0.1);
+                //Utility.AccurateWaitSeconds(0.1);
                 Assert.AreEqual(-1, d.Get(-0.1 * (i + 1)), AcceptibleError);
             }
         }
@@ -41,10 +43,11 @@ namespace IndependentTests.NILabviewTests
         public void DerivativePositiveTest100hz()
         {
             Derivative d = new Derivative(0);
+            d.Dt = 0.01;
             Assert.AreEqual(0, d.Get(0), double.Epsilon);
             for (int i = 0; i < TestRepeats; i++)
             {
-                Utility.AccurateWaitSeconds(0.01);
+                //Utility.AccurateWaitSeconds(0.01);
                 Assert.AreEqual(1, d.Get(0.01 * (i + 1)), AcceptibleError);
             }
         }
@@ -53,10 +56,11 @@ namespace IndependentTests.NILabviewTests
         public void DerivativeNegativeTest100hz()
         {
             Derivative d = new Derivative(0);
+            d.Dt = 0.01;
             Assert.AreEqual(0, d.Get(0), double.Epsilon);
             for (int i = 0; i < TestRepeats; i++)
             {
-                Utility.AccurateWaitSeconds(0.01);
+                //Utility.AccurateWaitSeconds(0.01);
                 Assert.AreEqual(-1, d.Get(-0.01 * (i + 1)), AcceptibleError);
             }
         }

--- a/IndependentTests/NILabviewTests/IntegralTest.cs
+++ b/IndependentTests/NILabviewTests/IntegralTest.cs
@@ -13,7 +13,8 @@ namespace IndependentTests.NILabviewTests
         public void PositiveIntegralTest1Step()
         {
             Integral t = new Integral();
-            Utility.AccurateWaitSeconds(1);
+            //Utility.AccurateWaitSeconds(1);
+            t.Dt = 1.0;
             Assert.AreEqual(1, t.Get(1), 0.02);
         }
 
@@ -21,9 +22,10 @@ namespace IndependentTests.NILabviewTests
         public void PositiveIntegralTest10Step()
         {
             Integral t = new Integral();
+            t.Dt = 0.1;
             for(int i = 0; i < 10; i++)
             {
-                Utility.AccurateWaitMilliseconds(100);
+                //Utility.AccurateWaitMilliseconds(100);
                 Assert.AreEqual(0.1 * (i + 1), t.Get(1), 0.02);
             }
         }
@@ -32,7 +34,8 @@ namespace IndependentTests.NILabviewTests
         public void NegativeIntegralTest1Step()
         {
             Integral t = new Integral();
-            Utility.AccurateWaitSeconds(1);
+            t.Dt = 1;
+            //Utility.AccurateWaitSeconds(1);
             Assert.AreEqual(-1, t.Get(-1), 0.02);
         }
 
@@ -40,9 +43,10 @@ namespace IndependentTests.NILabviewTests
         public void NegativeIntegralTest10Step()
         {
             Integral t = new Integral();
+            t.Dt = 0.1;
             for (int i = 0; i < 10; i++)
             {
-                Utility.AccurateWaitMilliseconds(100);
+                //Utility.AccurateWaitMilliseconds(100);
                 Assert.AreEqual(-0.1 * (i + 1), t.Get(-1), 0.02);
             }
         }


### PR DESCRIPTION
Hey Guys.

I spent some time tonight working on some ways to make delta time better.

The first was that the accurate wait implementation had a few issues. First it was an spin wait. Thats not a large issue, unless you try and sleep for more then about 20 ms. Any greater then that, and you start taking up time from the CPU from doing other things. Its possible to detect if you are running greater then 20 milliseconds, and do a regular Thread.Sleep until you get much closer to the precise time you need. The other issue is that grabbing the ElapsedSeconds from the stopwatch object is actually a pretty slow process, and only accurate to a few milliseconds. If you use CPU Ticks instead, and calculate the necessary number of ticks before the spin wait, you get a much more accurate wait with much less cpu usage. I also copy pasted the Utility test to test the millisecond implementation too.

The second commit makes the tick change to DeltaTime too so it can be alot more accurate too.

The 3rd thing is more of a unit test thing. Unit tests are usually only for testing the front end of your code, and do not usually depend on the back end implementation. Having the derivative and Integral tests depends on a dynamically calculated dt is not really the goal of unit testing, as all we need to do is check that the math is right given a specific dt. So those tests, for better stability and actual usage, should use a fixed dt. Once we do that, there is a Range attribute you can apply to a test case's parameters, so you would be able to check that the math is right for multiple dt's without duplicating code.

For the things we do, its good to have some back end code testing, but the accurate wait tests already do that, so no need to test it multiple times and introduce an easy place to create errors.

Are you guys OK with these?
